### PR TITLE
chore: issue와 pr과 관련된 workflow 추가

### DIFF
--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -1,0 +1,29 @@
+name: Issue Assignment
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  assign_assignee:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign issue to author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const assignees = issue.assignees;
+            if (assignees.length > 0) {
+              console.log('이미 assignee가 지정되어 있습니다.');
+              return;
+            }
+            const author = issue.user.login;
+            const issue_number = issue.number;
+            const { owner, repo } = context.repo;
+            await github.rest.issues.addAssignees({
+              owner: owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              assignees: [author]
+            });

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+
 jobs:
   assign_assignee:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-assignment.yml
+++ b/.github/workflows/pr-assignment.yml
@@ -1,0 +1,95 @@
+name: PR Assignment
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  get_meta_data:
+    runs-on: ubuntu-latest
+    outputs:
+      assignees: ${{ steps.get_meta_data.outputs.assignees }}
+      author: ${{ steps.get_meta_data.outputs.author }}
+      pr_number: ${{ steps.get_meta_data.outputs.pr_number }}
+      owner: ${{ steps.get_meta_data.outputs.owner }}
+      repo: ${{ steps.get_meta_data.outputs.repo }}
+    steps:
+      - name: Get PR meta data
+        uses: actions/github-script@v7
+        id: get_meta_data
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const assignees = pr.assignees.map(assignee => assignee.login);
+            const author = pr.user.login;
+            const pr_number = pr.number;
+            const { owner, repo } = context.repo;
+            core.setOutput('assignees', assignees);
+            core.setOutput('author', author);
+            core.setOutput('pr_number', pr_number);
+            core.setOutput('owner', owner);
+            core.setOutput('repo', repo);
+
+  assign_assignee:
+    runs-on: ubuntu-latest
+    needs: get_meta_data
+    steps:
+      - name: Assign PR to author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              const assignees = JSON.parse('${{ needs.get_meta_data.outputs.assignees || '[]' }}');
+              if (assignees.length > 0) {
+                console.log('이미 assignee가 지정되어 있습니다.');
+                return;
+              }
+              const author = '${{ needs.get_meta_data.outputs.author }}';
+              const pr_number = '${{ needs.get_meta_data.outputs.pr_number }}';
+              const owner = '${{ needs.get_meta_data.outputs.owner }}';
+              const repo = '${{ needs.get_meta_data.outputs.repo }}';
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: pr_number,
+                assignees: [author]
+              });
+            } catch(error) {
+              console.log('Assignee를 지정하는 중 오류가 발생했습니다:', error);
+            }
+
+  assign_reviewers:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    needs: get_meta_data
+    env:
+      REVIEWERS: cl-o-lc,dmdeh,HolMoly,yoouyeon,zelkovaria
+    steps:
+      - name: Assign reviewers
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              const assignees = JSON.parse('${{ needs.get_meta_data.outputs.assignees || '[]' }}');
+              const author = '${{ needs.get_meta_data.outputs.author }}';
+              const pr_number = '${{ needs.get_meta_data.outputs.pr_number }}';
+              const owner = '${{ needs.get_meta_data.outputs.owner }}';
+              const repo = '${{ needs.get_meta_data.outputs.repo }}';
+              const reviewers = process.env.REVIEWERS.split(',');
+              // author와 assignees를 제외한 reviewers 목록을 필터링
+              const filteredReviewers = reviewers.filter(reviewer => {
+                return reviewer !== author && !assignees.includes(reviewer);
+              });
+              if (filteredReviewers.length === 0) {
+                console.log('할당할 reviewer가 없습니다.');
+                return;
+              }
+              await github.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number: pr_number,
+                reviewers: filteredReviewers
+              });
+            } catch (error) {
+              console.log('reviewer를 지정하는 중 오류가 발생했습니다:', error);
+            }

--- a/.github/workflows/pr-assignment.yml
+++ b/.github/workflows/pr-assignment.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, ready_for_review, reopened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   get_meta_data:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## PR 설명

issue와 pr을 올렸을 때 assignee를 지정하고 review를 요청하는 workflow를 추가했습니다.

## ✅ 완료한 기능 명세

- **issue** (assign_assignee)
  - assignee가 없는 경우에는 이슈를 올린 사람을 assignee로 지정합니다.
  - assignee가 있는 경우에는 추가로 지정하지 않습니다.
- **pr assignee** (assign_assignee)
  - assignee가 없는 경우에는 pr을 올린 사람을 assignee로 지정합니다.
  - assignee가 있는 경우에는 추가로 지정하지 않습니다.
- **pr reviewer** (assign_reviewers)
  - REVIEWERS의 유저들 중에서 pr 작성자와 assignee를 제외한 모두에게 review를 요청합니다
  - draft 상태에서는 리뷰를 요청하지 않습니다.

## 📸 스크린샷

| PR action | Issue action |
|---|---|
| <img width="659" alt="Screen_Shot 2025-05-18 21 13 07" src="https://github.com/user-attachments/assets/6086f18c-c065-4f44-9b72-7b977fcd44c3" /> | 이 워크플로우가 아직 default 브랜치에 머지되지 않아서 동작은 개인 레포지토리에서 확인했습니다 🥲 |

Close #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced automated assignment of new issues to their authors.
	- Added automated assignment of pull requests to their authors and designated reviewers, streamlining the review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->