### PR TITLE
feat: 공통 모달 구현

### DIFF
--- a/src/app/@modal/(.)memo/add/page.tsx
+++ b/src/app/@modal/(.)memo/add/page.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { FormEvent } from 'react';
+import { Input, TextArea } from '@/components/ui/inputs';
+import { Modal } from '@/components/ui/modal/index';
+import { MEMO_CONTENT_MAX_LENGTH } from '@/constants/memo';
+
+const AddMemoModal = () => {
+  const saveMemo = (formEvent: FormEvent<HTMLFormElement>) => {
+    formEvent.preventDefault();
+
+    const formData = new FormData(formEvent.currentTarget);
+    const title = formData.get('title')?.toString().trim();
+    const content = formData.get('content')?.toString().trim();
+
+    if (!title || !content) {
+      alert('제목과 내용을 모두 입력해주세요.');
+      return;
+    }
+    if (content.length > MEMO_CONTENT_MAX_LENGTH) {
+      alert(`내용은 ${MEMO_CONTENT_MAX_LENGTH}자 이내로 입력해주세요.`);
+      return;
+    }
+
+    console.log('[TODO] 메모 저장 로직 추가: ', { title, content }); // TODO
+  };
+
+  return (
+    <Modal title="메모 추가" submitText="메모 저장" formId="add-memo-form">
+      <form
+        className="flex flex-col gap-4"
+        onSubmit={saveMemo}
+        id="add-memo-form"
+      >
+        <label htmlFor="memo-title" className="block font-medium text-black">
+          제목
+        </label>
+        <Input
+          type="text"
+          placeholder="제목을 입력하세요"
+          id="memo-title"
+          name="title"
+        />
+        <label htmlFor="memo-content" className="block font-medium text-black">
+          내용
+        </label>
+        <TextArea
+          maxLength={MEMO_CONTENT_MAX_LENGTH}
+          placeholder="내용을 입력하세요"
+          id="memo-content"
+          name="content"
+          rows={3}
+        />
+      </form>
+    </Modal>
+  );
+};
+
+export default AddMemoModal;

--- a/src/app/@modal/default.tsx
+++ b/src/app/@modal/default.tsx
@@ -1,0 +1,7 @@
+// NOTE : 모달이 없을 때는 아무것도 렌더링하지 않음
+
+const Default = () => {
+  return null;
+};
+
+export default Default;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { Geist, Geist_Mono } from 'next/font/google';
-import './globals.css';
+import '@/styles/globals.css';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 
@@ -13,8 +14,10 @@ const geistMono = Geist_Mono({
 
 export default function RootLayout({
   children,
+  modal,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
+  modal: ReactNode;
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -23,6 +26,7 @@ export default function RootLayout({
         suppressHydrationWarning
       >
         {children}
+        {modal}
       </body>
     </html>
   );

--- a/src/app/memo/add/page.tsx
+++ b/src/app/memo/add/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from 'next/navigation';
+
+// NOTE : /memo/add 경로는 모달로만 사용하므로, url로 직접 접근하면 모달을 사용하는 페이지인 홈으로 리다이렉트합니다.
+const AddMemoPage = () => {
+  redirect('/');
+  return null;
+};
+
+export default AddMemoPage;

--- a/src/components/home/memo/memo-item.tsx
+++ b/src/components/home/memo/memo-item.tsx
@@ -1,9 +1,9 @@
-import { MemoItem } from '@/types/memo';
+import { Memo } from '@/types/memo';
 import React from 'react';
 import { IoIosMore } from 'react-icons/io';
 
 interface MemoListProps {
-  memo: MemoItem;
+  memo: Memo;
 }
 const MemoListItem = ({ memo }: MemoListProps) => {
   return (

--- a/src/components/home/memo/memo.tsx
+++ b/src/components/home/memo/memo.tsx
@@ -2,15 +2,20 @@ import { mockMemoData } from '@/mocks/memo';
 import React from 'react';
 import { FiPlus } from 'react-icons/fi';
 import MemoListItem from './memo-item';
+import Link from 'next/link';
 
 const Memo = () => {
   return (
     <div className="rounded-xl h-full w-full">
       <div className="flex justify-between items-center">
         <h2>메모</h2>
-        <button className="text-xl cursor-pointer">
+        <Link
+          href="/memo/add"
+          scroll={false} // NOTE : 모달로 사용하기 위한 스크롤 방지 (https://github.com/shadcn-ui/ui/issues/1355)
+          className="text-xl cursor-pointer"
+        >
           <FiPlus />
-        </button>
+        </Link>
       </div>
       <ul className="flex flex-col gap-1 mt-4">
         {mockMemoData.length > 0 ? (

--- a/src/components/ui/buttons/button.tsx
+++ b/src/components/ui/buttons/button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ButtonHTMLAttributes } from 'react';
+import { ButtonHTMLAttributes, forwardRef } from 'react';
 
 const BUTTON_VARIANTS = {
   primary: 'bg-[#8B5CF6] text-[#FFFEFE] hover:bg-[#7d53dd]',
@@ -12,15 +12,20 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: keyof typeof BUTTON_VARIANTS;
 }
 
-const Button = ({ variant = 'primary', className, ...props }: ButtonProps) => {
-  return (
-    <button
-      className={`px-3 py-2.5 rounded-md text-sm font-medium cursor-pointer ${BUTTON_VARIANTS[variant]} ${className || ''}`}
-      {...props}
-    >
-      {props.children}
-    </button>
-  );
-};
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = 'primary', className, type = 'button', ...props }, ref) => {
+    return (
+      <button
+        className={`px-3 py-2.5 rounded-md text-sm font-medium cursor-pointer ${BUTTON_VARIANTS[variant]} ${className || ''}`}
+        type={type} // NOTE: 기본값을 'button'으로 설정해서 의도치않은 submit 방지
+        ref={ref}
+        {...props}
+      >
+        {props.children}
+      </button>
+    );
+  },
+);
 
+Button.displayName = 'Button';
 export default Button;

--- a/src/components/ui/buttons/button.tsx
+++ b/src/components/ui/buttons/button.tsx
@@ -13,7 +13,10 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ variant = 'primary', className, type = 'button', ...props }, ref) => {
+  (
+    { variant = 'primary', className, type = 'button', children, ...props },
+    ref,
+  ) => {
     return (
       <button
         className={`px-3 py-2.5 rounded-md text-sm font-medium cursor-pointer ${BUTTON_VARIANTS[variant]} ${className || ''}`}
@@ -21,7 +24,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         {...props}
       >
-        {props.children}
+        {children}
       </button>
     );
   },

--- a/src/components/ui/buttons/button.tsx
+++ b/src/components/ui/buttons/button.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { ButtonHTMLAttributes } from 'react';
+
+const BUTTON_VARIANTS = {
+  primary: 'bg-[#8B5CF6] text-[#FFFEFE] hover:bg-[#7d53dd]',
+  secondary: 'bg-[#ECECEC] text-black hover:bg-[#D9D9D9]',
+  outline: 'border border-[#747775] text-[#1F1F1F] bg-transparent', // NOTE : google 로그인 버튼 디자인 참고 (https://developers.google.com/identity/branding-guidelines)
+} as const;
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: keyof typeof BUTTON_VARIANTS;
+}
+
+const Button = ({ variant = 'primary', className, ...props }: ButtonProps) => {
+  return (
+    <button
+      className={`px-3 py-2.5 rounded-md text-sm font-medium cursor-pointer ${BUTTON_VARIANTS[variant]} ${className || ''}`}
+      {...props}
+    >
+      {props.children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/ui/buttons/index.ts
+++ b/src/components/ui/buttons/index.ts
@@ -1,0 +1,1 @@
+export { default as Button } from './button';

--- a/src/components/ui/inputs/index.ts
+++ b/src/components/ui/inputs/index.ts
@@ -1,0 +1,2 @@
+export { default as Input } from './input';
+export { default as TextArea } from './text-area';

--- a/src/components/ui/inputs/input.tsx
+++ b/src/components/ui/inputs/input.tsx
@@ -1,14 +1,18 @@
-import { ComponentPropsWithRef, InputHTMLAttributes } from 'react';
+import { ComponentPropsWithRef, forwardRef } from 'react';
 
 interface InputProps extends ComponentPropsWithRef<'input'> {}
 
-const Input = ({ className, ...props }: InputProps) => {
-  return (
-    <input
-      className={`w-full rounded-md border border-[#8B5CF6] px-3 py-2.5 text-black placeholder:text-[#989898] focus:outline-[#6f4ac5] focus-visible:outline-[#6f4ac5] ${className || ''}`}
-      {...props}
-    />
-  );
-};
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <input
+        className={`w-full rounded-md border border-[#8B5CF6] px-3 py-2.5 text-black placeholder:text-[#989898] focus:outline-[#6f4ac5] focus-visible:outline-[#6f4ac5] ${className || ''}`}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
 
+Input.displayName = 'Input';
 export default Input;

--- a/src/components/ui/inputs/input.tsx
+++ b/src/components/ui/inputs/input.tsx
@@ -5,7 +5,7 @@ interface InputProps extends ComponentPropsWithRef<'input'> {}
 const Input = ({ className, ...props }: InputProps) => {
   return (
     <input
-      className={`w-full rounded-md border border-[#8B5CF6] px-3 py-2.5 text-black placeholder:text-[#989898] focus:outline-[##6f4ac5] focus-visible:outline-[#6f4ac5] ${className || ''}`}
+      className={`w-full rounded-md border border-[#8B5CF6] px-3 py-2.5 text-black placeholder:text-[#989898] focus:outline-[#6f4ac5] focus-visible:outline-[#6f4ac5] ${className || ''}`}
       {...props}
     />
   );

--- a/src/components/ui/inputs/input.tsx
+++ b/src/components/ui/inputs/input.tsx
@@ -1,0 +1,14 @@
+import { ComponentPropsWithRef, InputHTMLAttributes } from 'react';
+
+interface InputProps extends ComponentPropsWithRef<'input'> {}
+
+const Input = ({ className, ...props }: InputProps) => {
+  return (
+    <input
+      className={`w-full rounded-md border border-[#8B5CF6] px-3 py-2.5 text-black placeholder:text-[#989898] focus:outline-[##6f4ac5] focus-visible:outline-[#6f4ac5] ${className || ''}`}
+      {...props}
+    />
+  );
+};
+
+export default Input;

--- a/src/components/ui/inputs/text-area.tsx
+++ b/src/components/ui/inputs/text-area.tsx
@@ -40,7 +40,7 @@ const TextArea = ({
       className={`w-full px-3 py-2.5 rounded-md border border-[#8B5CF6] ${className || ''}`}
     >
       <textarea
-        className="w-full px-1 text-black placeholder:text-[#989898] focus:outline-[##6f4ac5] focus-visible:outline-[#6f4ac5]"
+        className="w-full px-1 text-black placeholder:text-[#989898] focus:outline-[#6f4ac5] focus-visible:outline-[#6f4ac5]"
         onChange={changeValue}
         value={isControlled ? value : undefined} // 제어 컴포넌트인 경우 부모 컴포넌트의 value 사용
         {...props}

--- a/src/components/ui/inputs/text-area.tsx
+++ b/src/components/ui/inputs/text-area.tsx
@@ -17,6 +17,9 @@ const TextArea = ({
 
   const isControlled = value !== undefined;
   const isCheckMaxLength = maxLength !== undefined;
+  const currentLength = isControlled
+    ? value.toString().length
+    : internalValue.toString().length;
 
   const changeValue = (event: ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = event.target.value;
@@ -47,7 +50,7 @@ const TextArea = ({
       />
       {isCheckMaxLength && (
         <div className="mt-1 text-right text-xs text-[#989898]">
-          {internalValue.toString().length}/{maxLength}
+          {currentLength}/{maxLength}
         </div>
       )}
     </div>

--- a/src/components/ui/inputs/text-area.tsx
+++ b/src/components/ui/inputs/text-area.tsx
@@ -1,60 +1,63 @@
 'use client';
 
-import { useState, ComponentPropsWithRef, ChangeEvent } from 'react';
+import {
+  forwardRef,
+  useState,
+  ComponentPropsWithRef,
+  ChangeEvent,
+} from 'react';
 
 interface TextAreaProps extends ComponentPropsWithRef<'textarea'> {
   maxLength?: number;
 }
 
-const TextArea = ({
-  className,
-  maxLength,
-  onChange,
-  value,
-  ...props
-}: TextAreaProps) => {
-  const [internalValue, setInternalValue] = useState(value || ''); // NOTE : 비제어 input에서도 글자수를 표시하기 위한 내부 상태
+const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  ({ className, maxLength, onChange, value, ...props }, ref) => {
+    const [internalValue, setInternalValue] = useState(value || ''); // NOTE : 비제어 input에서도 글자수를 표시하기 위한 내부 상태
 
-  const isControlled = value !== undefined;
-  const isCheckMaxLength = maxLength !== undefined;
-  const currentLength = isControlled
-    ? value.toString().length
-    : internalValue.toString().length;
+    const isControlled = value !== undefined;
+    const isCheckMaxLength = maxLength !== undefined;
+    const currentLength = isControlled
+      ? value.toString().length
+      : internalValue.toString().length;
 
-  const changeValue = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    const newValue = event.target.value;
-    if (maxLength) {
-      // 글자수가 maxLength를 초과하지 않도록 제한
-      if (newValue.length > maxLength) {
-        event.target.value = newValue.slice(0, maxLength);
-        return; // 글자수가 초과하면 상태 업데이트를 하지 않음
+    const changeValue = (event: ChangeEvent<HTMLTextAreaElement>) => {
+      const newValue = event.target.value;
+      if (maxLength) {
+        // 글자수가 maxLength를 초과하지 않도록 제한
+        if (newValue.length > maxLength) {
+          event.target.value = newValue.slice(0, maxLength);
+          return; // 글자수가 초과하면 상태 업데이트를 하지 않음
+        }
       }
-    }
-    if (!isControlled) {
-      setInternalValue(newValue); // 비제어 컴포넌트인 경우 내부 상태 업데이트
-    }
-    if (onChange) {
-      onChange(event); // 부모 컴포넌트의 onChange 핸들러 호출
-    }
-  };
+      if (!isControlled) {
+        setInternalValue(newValue); // 비제어 컴포넌트인 경우 내부 상태 업데이트
+      }
+      if (onChange) {
+        onChange(event); // 부모 컴포넌트의 onChange 핸들러 호출
+      }
+    };
 
-  return (
-    <div
-      className={`w-full px-3 py-2.5 rounded-md border border-[#8B5CF6] ${className || ''}`}
-    >
-      <textarea
-        className="w-full px-1 text-black placeholder:text-[#989898] focus:outline-[#6f4ac5] focus-visible:outline-[#6f4ac5]"
-        onChange={changeValue}
-        value={isControlled ? value : undefined} // 제어 컴포넌트인 경우 부모 컴포넌트의 value 사용
-        {...props}
-      />
-      {isCheckMaxLength && (
-        <div className="mt-1 text-right text-xs text-[#989898]">
-          {currentLength}/{maxLength}
-        </div>
-      )}
-    </div>
-  );
-};
+    return (
+      <div
+        className={`w-full px-3 py-2.5 rounded-md border border-[#8B5CF6] ${className || ''}`}
+      >
+        <textarea
+          className="w-full px-1 text-black placeholder:text-[#989898] focus:outline-[#6f4ac5] focus-visible:outline-[#6f4ac5]"
+          onChange={changeValue}
+          value={isControlled ? value : undefined} // 제어 컴포넌트인 경우 부모 컴포넌트의 value 사용
+          ref={ref}
+          {...props}
+        />
+        {isCheckMaxLength && (
+          <div className="mt-1 text-right text-xs text-[#989898]">
+            {currentLength}/{maxLength}
+          </div>
+        )}
+      </div>
+    );
+  },
+);
 
+TextArea.displayName = 'TextArea';
 export default TextArea;

--- a/src/components/ui/inputs/text-area.tsx
+++ b/src/components/ui/inputs/text-area.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState, ComponentPropsWithRef, ChangeEvent } from 'react';
+
+interface TextAreaProps extends ComponentPropsWithRef<'textarea'> {
+  maxLength?: number;
+}
+
+const TextArea = ({
+  className,
+  maxLength,
+  onChange,
+  value,
+  ...props
+}: TextAreaProps) => {
+  const [internalValue, setInternalValue] = useState(value || ''); // NOTE : 비제어 input에서도 글자수를 표시하기 위한 내부 상태
+
+  const isControlled = value !== undefined;
+  const isCheckMaxLength = maxLength !== undefined;
+
+  const changeValue = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = event.target.value;
+    if (maxLength) {
+      // 글자수가 maxLength를 초과하지 않도록 제한
+      if (newValue.length > maxLength) {
+        event.target.value = newValue.slice(0, maxLength);
+        return; // 글자수가 초과하면 상태 업데이트를 하지 않음
+      }
+    }
+    if (!isControlled) {
+      setInternalValue(newValue); // 비제어 컴포넌트인 경우 내부 상태 업데이트
+    }
+    if (onChange) {
+      onChange(event); // 부모 컴포넌트의 onChange 핸들러 호출
+    }
+  };
+
+  return (
+    <div
+      className={`w-full px-3 py-2.5 rounded-md border border-[#8B5CF6] ${className || ''}`}
+    >
+      <textarea
+        className="w-full px-1 text-black placeholder:text-[#989898] focus:outline-[##6f4ac5] focus-visible:outline-[#6f4ac5]"
+        onChange={changeValue}
+        value={isControlled ? value : undefined} // 제어 컴포넌트인 경우 부모 컴포넌트의 value 사용
+        {...props}
+      />
+      {isCheckMaxLength && (
+        <div className="mt-1 text-right text-xs text-[#989898]">
+          {internalValue.toString().length}/{maxLength}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TextArea;

--- a/src/components/ui/modal/index.ts
+++ b/src/components/ui/modal/index.ts
@@ -1,0 +1,1 @@
+export { default as Modal } from './modal';

--- a/src/components/ui/modal/modal-body.tsx
+++ b/src/components/ui/modal/modal-body.tsx
@@ -1,0 +1,11 @@
+import { PropsWithChildren } from 'react';
+
+const ModalBody = ({ children, ...props }: PropsWithChildren) => {
+  return (
+    <div className="p-4 overflow-y-auto border-y border-y-[#8B5CF6]" {...props}>
+      {children}
+    </div>
+  );
+};
+
+export default ModalBody;

--- a/src/components/ui/modal/modal-footer.tsx
+++ b/src/components/ui/modal/modal-footer.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@/components/ui/buttons';
+
+interface ModalFooterProps {
+  onClose?: () => void;
+  onSubmit?: () => void;
+  submitText?: string;
+  formId?: string; // form 제출 이벤트를 연결해야 할 때 사용
+}
+
+const ModalFooter = ({
+  onClose,
+  onSubmit,
+  submitText = '저장',
+  formId,
+}: ModalFooterProps) => {
+  return (
+    <div className="p-4 w-full flex justify-end gap-2">
+      <Button variant="secondary" onClick={onClose}>
+        닫기
+      </Button>
+      <Button onClick={onSubmit} form={formId}>
+        {submitText}
+      </Button>
+    </div>
+  );
+};
+
+export default ModalFooter;

--- a/src/components/ui/modal/modal-footer.tsx
+++ b/src/components/ui/modal/modal-footer.tsx
@@ -18,7 +18,11 @@ const ModalFooter = ({
       <Button variant="secondary" onClick={onClose}>
         닫기
       </Button>
-      <Button onClick={onSubmit} form={formId}>
+      <Button
+        onClick={onSubmit}
+        form={formId}
+        type={formId ? 'submit' : 'button'}
+      >
         {submitText}
       </Button>
     </div>

--- a/src/components/ui/modal/modal-header.tsx
+++ b/src/components/ui/modal/modal-header.tsx
@@ -1,0 +1,13 @@
+interface ModalHeaderProps {
+  title: string;
+}
+
+const ModalHeader = ({ title }: ModalHeaderProps) => {
+  return (
+    <h3 id="modal-header" className="p-4 text-2xl text-black">
+      {title}
+    </h3>
+  );
+};
+
+export default ModalHeader;

--- a/src/components/ui/modal/modal.tsx
+++ b/src/components/ui/modal/modal.tsx
@@ -30,13 +30,13 @@ const Modal = ({
 
   return (
     <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="modal-header"
       className="fixed inset-0 z-50 flex items-center justify-center bg-[#3b3b3b]/60"
       onClick={onClose || goBack}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-header"
         className={`rounded-2xl bg-[#FFFEFE] max-w-xl min-w-96 ${className || ''}`}
         onClick={(clickEvent) => clickEvent.stopPropagation()} // NOTE : modal content 클릭 시에 overlay로 클릭 이벤트가 전파되지 않도록 함
         {...props}

--- a/src/components/ui/modal/modal.tsx
+++ b/src/components/ui/modal/modal.tsx
@@ -1,0 +1,57 @@
+import { HTMLAttributes, PropsWithChildren } from 'react';
+import { useRouter } from 'next/navigation';
+import ModalHeader from './modal-header';
+import ModalBody from './modal-body';
+import ModalFooter from './modal-footer';
+
+interface ModalProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>> {
+  title: string;
+  onClose?: () => void;
+  onSubmit?: () => void;
+  submitText?: string;
+  formId?: string; // form 제출 이벤트를 연결해야 할 때 사용
+}
+
+const Modal = ({
+  title,
+  onClose,
+  onSubmit,
+  formId,
+  submitText,
+  className,
+  children,
+  ...props
+}: ModalProps) => {
+  const router = useRouter();
+
+  const goBack = () => {
+    router.back();
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-header"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[#3b3b3b]/60"
+      onClick={onClose || goBack}
+    >
+      <div
+        className={`rounded-2xl bg-[#FFFEFE] max-w-xl min-w-96 ${className || ''}`}
+        onClick={(clickEvent) => clickEvent.stopPropagation()} // NOTE : modal content 클릭 시에 overlay로 클릭 이벤트가 전파되지 않도록 함
+        {...props}
+      >
+        <ModalHeader title={title} />
+        <ModalBody>{children}</ModalBody>
+        <ModalFooter
+          onClose={onClose || goBack}
+          onSubmit={onSubmit}
+          submitText={submitText}
+          formId={formId}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/constants/memo.ts
+++ b/src/constants/memo.ts
@@ -1,0 +1,2 @@
+export const MEMO_TITLE_MAX_LENGTH = 20; // TODO : 논의 후 확정
+export const MEMO_CONTENT_MAX_LENGTH = 300;

--- a/src/mocks/memo.ts
+++ b/src/mocks/memo.ts
@@ -1,23 +1,23 @@
-import { MemoItem } from '@/types/memo';
+import { Memo } from '@/types/memo';
 
-export const mockMemoData: MemoItem[] = [
+export const mockMemoData: Memo[] = [
   {
-    id: 1,
+    id: '1',
     title: '카더가든 노래좋다',
     content: '킨더조이 아저씨 짱',
   },
   {
-    id: 2,
+    id: '2',
     title: '음악 반복재생',
     content: '가까운 듯 먼 그대여 들어주세요',
   },
   {
-    id: 3,
+    id: '3',
     title: '나무도 좋아요',
     content: '우리의 밤을 외워요까지 같이 들어야함',
   },
   {
-    id: 4,
+    id: '4',
     title: '지금 플리 deja vu',
     content:
       'she thinks its special, but its all reused That was our place, I found it first I made the jokes',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,12 +7,13 @@
   --foreground: #171717;
 }
 
-@media (prefers-color-scheme: dark) {
+/* NOTE : 아직 다크모드를 지원하지 않으므로 주석으로 처리함 */
+/* @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
   }
-}
+} */
 
 body {
   background: var(--background);

--- a/src/types/memo.ts
+++ b/src/types/memo.ts
@@ -1,5 +1,5 @@
-export interface MemoItem {
-  id: number;
+export interface Memo {
+  id: string;
   title: string;
   content: string;
 }


### PR DESCRIPTION
## PR 설명

프로젝트의 모달에서 공통적으로 사용할 모달과 모달에서 사용할 공통 컴포넌트를 구현했습니다.

## ✅ 완료한 기능 명세

related to #4

- 공통 모달 컴포넌트 구현 (dcdd7001d90656f13d592b030357c2338318caea)
- 모달에서 사용할 입력, 버튼 컴포넌트 구현 (2f6e4a20f5da0824ece20ba99a7d51de0c3ba7e1, 2e9f3ead6f1ad1a3c6fe2af440d8aad64d41afcb)
- 컴포넌트 확인용 메모 추가 모달 구현 (b5ce2b31f69485bc606422f68a2a8b5a40c48127)
- 아직 다크모드를 지원하지 않기 때문에 다크모드 미디어쿼리를 주석으로 처리 (제 크롬에서는 글자가 모두 흰색으로 나오더라구요...) (47c02e4c3c46e802cedd95a6240f667eddf4f641)
- 데이터 타입 명세에 맞게 메모 아이템 타입을 조금 수정했습니다. (타입 이름 변경, id 타입 변경) (cc43f0508301ca94a6583cc0b116be27f3d4dfc7)

## 📸 스크린샷

https://github.com/user-attachments/assets/846913a8-7480-4099-9ddd-110ac7b35724


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 메모 추가를 위한 모달 컴포넌트가 새로 도입되었습니다.
  - 모달의 헤더, 바디, 푸터 등의 UI 컴포넌트가 추가되었습니다.
  - 버튼, 입력창, 텍스트 영역, 모달 등 UI 재사용 컴포넌트가 확장되었습니다.

- **개선사항**
  - `/memo/add` 경로는 직접 접근 시 홈으로 리다이렉트되어 모달 전용임을 명확히 했습니다.
  - 메모 제목과 내용의 최대 글자 수 제한이 적용되어 입력 검증이 강화되었습니다.
  - 메모 데이터 타입이 `string` ID를 사용하는 것으로 일관성 있게 변경되었습니다.
  - 레이아웃에 `modal` prop이 추가되어 모달 콘텐츠와 함께 렌더링됩니다.

- **버그 수정**
  - `/memo/add` 경로에 직접 접근 시 홈으로 리다이렉트되어 접근 제어가 강화되었습니다.

- **리팩터링**
  - 메모 데이터 타입이 `Memo`로 변경되어 일관성을 확보하였으며, 타입 선언이 정리되었습니다.
  - 내부 구조와 타입이 개선되어 유지보수가 용이해졌습니다.

- **스타일**
  - 다크 모드 지원 CSS가 비활성화되어 현재 다크 모드 적용이 중단되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->